### PR TITLE
Adds aggregate plugin registry

### DIFF
--- a/pkg/plugin/registry/aggregate.go
+++ b/pkg/plugin/registry/aggregate.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"context"
+	"iter"
+	"maps"
+
+	"github.com/unstoppablemango/ux/pkg/plugin"
+	"github.com/unstoppablemango/ux/pkg/ux"
+)
+
+type Aggregate []plugin.Registry
+
+func (registries Aggregate) List(ctx context.Context) (iter.Seq2[string, ux.Plugin], error) {
+	plugins := map[string]ux.Plugin{}
+	for _, r := range registries {
+		if list, err := r.List(ctx); err != nil {
+			return nil, err
+		} else {
+			maps.Insert(plugins, list)
+		}
+	}
+
+	return maps.All(plugins), nil
+}


### PR DESCRIPTION
Implements an aggregate plugin registry that combines multiple plugin registries into a single, unified view.

This allows listing plugins from various sources as if they were in a single registry, simplifying plugin discovery and management.
