### PR TITLE
Adds tags to trigger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: [v*.*.*]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Configures CI to run on tagged commits, specifically those
matching the semantic versioning pattern 'v*.*.*'. This allows
for automated builds and tests when new versions are tagged.
