### PR TITLE
Idk why I did that and it seems wrong so Im changing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +22,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Build should run on `main` for dependency caching
Lint has no reason to run on main...