### PR TITLE
Refactors CLI input parsing

### DIFF
--- a/pkg/cli/input.go
+++ b/pkg/cli/input.go
@@ -1,37 +1,27 @@
 package cli
 
 import (
-	"iter"
-	"maps"
-
+	"github.com/unmango/go/iter"
 	ux "github.com/unstoppablemango/ux/pkg"
 )
 
 type Input struct {
-	Sources map[string]ux.Source
-	Sinks   map[string]ux.Sink
+	sources iter.Seq2[string, ux.Source]
+	sinks   iter.Seq2[string, ux.Sink]
 }
 
-func (i *Input) addSource(key string, source ux.Source) {
-	if i.Sources == nil {
-		i.Sources = map[string]ux.Source{}
+func (i Input) Sources() iter.Seq2[string, ux.Source] {
+	if i.sources == nil {
+		return iter.Empty2[string, ux.Source]()
+	} else {
+		return i.sources
 	}
-
-	i.Sources[key] = source
 }
 
-func (i *Input) addSink(key string, sink ux.Sink) {
-	if i.Sinks == nil {
-		i.Sinks = map[string]ux.Sink{}
+func (i Input) Sinks() iter.Seq2[string, ux.Sink] {
+	if i.sinks == nil {
+		return iter.Empty2[string, ux.Sink]()
+	} else {
+		return i.sinks
 	}
-
-	i.Sinks[key] = sink
-}
-
-func (i Input) GetSources() iter.Seq2[string, ux.Source] {
-	return maps.All(i.Sources)
-}
-
-func (i Input) GetSinks() iter.Seq2[string, ux.Sink] {
-	return maps.All(i.Sinks)
 }

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -1,10 +1,44 @@
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"iter"
+	"maps"
+
+	"github.com/spf13/cobra"
+	ux "github.com/unstoppablemango/ux/pkg"
+	"github.com/unstoppablemango/ux/pkg/cli/sink"
+	"github.com/unstoppablemango/ux/pkg/cli/source"
+)
 
 type Options struct {
 	Inputs  []string
 	Outputs []string
+}
+
+func (opts Options) Sinks() (iter.Seq2[string, ux.Sink], error) {
+	sinks := map[string]ux.Sink{}
+	for _, o := range opts.Outputs {
+		if s, err := sink.Parse(o); err != nil {
+			return nil, err
+		} else {
+			sinks[o] = s
+		}
+	}
+
+	return maps.All(sinks), nil
+}
+
+func (opts Options) Sources() (iter.Seq2[string, ux.Source], error) {
+	sources := map[string]ux.Source{}
+	for _, i := range opts.Inputs {
+		if s, err := source.Parse(i); err != nil {
+			return nil, err
+		} else {
+			sources[i] = s
+		}
+	}
+
+	return maps.All(sources), nil
 }
 
 func Flags(cmd *cobra.Command, opts *Options) {

--- a/pkg/cli/parse.go
+++ b/pkg/cli/parse.go
@@ -3,19 +3,19 @@ package cli
 import (
 	"slices"
 
-	"github.com/unstoppablemango/ux/pkg/cli/sink"
+	"github.com/unmango/go/iter"
 	"github.com/unstoppablemango/ux/pkg/cli/source"
 )
 
 func Parse(opts Options, args []string) (i Input, err error) {
+	if i.sources, err = opts.Sources(); err != nil {
+		return i, err
+	}
 	if slices.Contains(args, "-") {
-		i.addSource("-", source.Stdin)
+		i.sources = iter.Append2(i.sources, "-", source.Stdin)
 	}
-	for _, x := range opts.Inputs {
-		i.addSource(x, source.File(x))
-	}
-	for _, x := range opts.Outputs {
-		i.addSink(x, sink.File(x))
+	if i.sinks, err = opts.Sinks(); err != nil {
+		return i, err
 	}
 
 	return i, nil

--- a/pkg/cli/parse_test.go
+++ b/pkg/cli/parse_test.go
@@ -12,6 +12,6 @@ var _ = Describe("Parse", func() {
 		input, err := cli.Parse(cli.Options{}, []string{"-"})
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(input.Sources).To(HaveKey("-"))
+		Expect(input.Sources()).To(HaveKey("-"))
 	})
 })

--- a/pkg/cli/sink/parse.go
+++ b/pkg/cli/sink/parse.go
@@ -1,0 +1,7 @@
+package sink
+
+import ux "github.com/unstoppablemango/ux/pkg"
+
+func Parse(o string) (ux.Sink, error) {
+	return File(o), nil
+}

--- a/pkg/cli/source/parse.go
+++ b/pkg/cli/source/parse.go
@@ -1,0 +1,7 @@
+package source
+
+import ux "github.com/unstoppablemango/ux/pkg"
+
+func Parse(i string) (ux.Source, error) {
+	return File(i), nil
+}

--- a/pkg/cli/source/source.go
+++ b/pkg/cli/source/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	ux "github.com/unstoppablemango/ux/pkg"
 	"github.com/unstoppablemango/ux/pkg/os"
 )
 
@@ -17,7 +18,7 @@ func OpenStdin(ctx context.Context) (io.Reader, error) {
 	return os.FromContext(ctx).Stdin(), nil
 }
 
-var Stdin stdin = OpenStdin
+var Stdin ux.Source = stdin(OpenStdin)
 
 type File string
 

--- a/pkg/input.go
+++ b/pkg/input.go
@@ -16,6 +16,6 @@ type (
 )
 
 type Input interface {
-	GetSources() iter.Seq2[string, Source]
-	GetSinks() iter.Seq2[string, Sink]
+	Sources() iter.Seq2[string, Source]
+	Sinks() iter.Seq2[string, Sink]
 }


### PR DESCRIPTION
Moves source and sink parsing into the `Options` struct, allowing deferred parsing and error handling closer to flag processing.

Uses iterators instead of maps for managing sources and sinks, improving flexibility and composability.
