### PR TITLE
Attempt to resolve the version when installed as a go tool

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -X github.com/unstoppablemango/ux/cmd.Version={{.Version}}
+      - -X github.com/unstoppablemango/ux/internal.Version={{.Version}}
 
 archives:
   - formats: [tar.gz]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.24@sha256:81bf5927dc91aefb42e2bc3a5abdbe9bb3bae8ba8b107e2a4cf43ce3402534c6 AS base
+FROM golang:1.24@sha256:db5d0afbfb4ab648af2393b92e87eaae9ad5e01132803d80caef91b5752d289c AS base
 
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=v0.0.1-docker
-ARG LDFLAGS="-X github.com/unstoppablemango/ux/cmd.Version=$VERSION"
+ARG LDFLAGS="-X github.com/unstoppablemango/ux/internal.Version=$VERSION"
 
 FROM base AS download
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM download AS build
 WORKDIR /src
 COPY cmd ./cmd
 COPY gen ./gen
+COPY internal ./internal
 COPY pkg ./pkg
 COPY main.go ./
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 _ != mkdir -p .make
-VERSION := v0.0.1-development
+VERSION ?= v0.0.1-development
 
 ##@ Tools
 
@@ -34,7 +34,7 @@ GO_CODEGEN  := ${GO_GRPC_SRC} ${GO_PB_SRC}
 
 ##@ Artifacts
 
-LDFLAGS := -X github.com/unstoppablemango/ux/cmd.Version=${VERSION}
+LDFLAGS := -X github.com/unstoppablemango/ux/internal.Version=${VERSION}
 bin/ux: ${GO_SRC} ## Build the ux CLI
 	$(GO) build -o $@ -ldflags='${LDFLAGS}'
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,42 +3,15 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"runtime"
-	"runtime/debug"
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
-)
-
-var (
-	BuildDate string
-	GitCommit string
-	GoArch    string
-	GoOs      string
-	GoVersion = runtime.Version()
-	Version   = "v0.0.1-development"
+	"github.com/unstoppablemango/ux/internal"
 )
 
 var versionCmd = NewVersion()
 
 func init() {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		var modified bool
-		for _, setting := range info.Settings {
-			switch setting.Key {
-			case "vcs.revision":
-				GitCommit = setting.Value
-			case "vcs.time":
-				BuildDate = setting.Value
-			case "vcs.modified":
-				modified = true
-			}
-		}
-		if modified {
-			GitCommit += "+DIRTY"
-		}
-	}
-
 	rootCmd.AddCommand(versionCmd)
 }
 
@@ -47,10 +20,16 @@ func NewVersion() *cobra.Command {
 		Use:   "version",
 		Short: "Print the version number",
 		Run: func(cmd *cobra.Command, args []string) {
+			version := internal.RuntimeVersion()
 			if isatty.IsTerminal(os.Stdout.Fd()) {
-				_, _ = fmt.Println(Version, GoVersion, GitCommit, BuildDate)
+				info := internal.ReadBuildInfo()
+				_, _ = fmt.Println(version,
+					info.GoVersion,
+					info.GitCommit,
+					info.BuildDate,
+				)
 			} else {
-				_, _ = fmt.Print(Version)
+				_, _ = fmt.Print(version)
 			}
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/unmango/go v0.4.1
 	go.uber.org/mock v0.5.2
+	golang.org/x/mod v0.24.0
 	google.golang.org/grpc v1.72.2
 	google.golang.org/protobuf v1.36.6
 )
@@ -292,7 +293,6 @@ require (
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
-	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/internal/build.go
+++ b/internal/build.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+type BuildInfo struct {
+	BuildDate string
+	GitCommit string
+	GoArch    string
+	GoOs      string
+	GoVersion string
+}
+
+func ReadBuildInfo() BuildInfo {
+	bi := BuildInfo{
+		GoVersion: runtime.Version(),
+		GoArch:    runtime.GOARCH,
+		GoOs:      runtime.GOOS,
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return bi
+	}
+
+	var modified bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			bi.GitCommit = setting.Value
+		case "vcs.time":
+			bi.BuildDate = setting.Value
+		case "vcs.modified":
+			modified = true
+		}
+	}
+	if modified {
+		bi.GitCommit += "+DIRTY"
+	}
+
+	return bi
+}

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,66 @@
+package internal
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/unstoppablemango/ux/internal/version"
+	"golang.org/x/mod/modfile"
+)
+
+var Version string = version.Development
+
+func IsDevelopment() bool {
+	switch Version {
+	case "", version.Development:
+		return true
+	default:
+		return false
+	}
+}
+
+func ReadGoMod() (*modfile.File, error) {
+	file, err := os.Open("go.mod")
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return modfile.Parse("go.mod", data, nil)
+}
+
+func GoToolVersion(file *modfile.File) (string, bool) {
+	// Go tools are indirect dependencies in the modfile
+	if r, found := GoModRequire(file); found && r.Indirect {
+		return r.Mod.Version, true
+	} else {
+		return "", false
+	}
+}
+
+func GoModRequire(file *modfile.File) (*modfile.Require, bool) {
+	for _, r := range file.Require {
+		if strings.HasPrefix(r.Mod.Path, "github.com/unstoppablemango/ux") {
+			return r, true
+		}
+	}
+
+	return nil, false
+}
+
+func RuntimeVersion() string {
+	if IsDevelopment() {
+		if mod, err := ReadGoMod(); err == nil {
+			if version, found := GoToolVersion(mod); found {
+				return version
+			}
+		}
+	}
+
+	return Version
+}

--- a/internal/version/development.go
+++ b/internal/version/development.go
@@ -1,0 +1,3 @@
+package version
+
+const Development = "v0.0.1-development"


### PR DESCRIPTION
There's probably a better way to do this, but I spend about an hour searching the go source and couldn't find a more specific route
