### PR TITLE
Restricts dprint job to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
   dprint:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     env:
       # renovate: datasource=github-tags depName=dprint/dprint
       DPRINT_VERSION: 0.50.0


### PR DESCRIPTION
Configures the dprint job to run only on pull requests.
This prevents unnecessary execution on other events,
optimizing CI resources.
