### PR TITLE
Renames output file with ".dummy" prefix

### DIFF
--- a/cmd/dummy/main.go
+++ b/cmd/dummy/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	uxv1alpha1 "github.com/unstoppablemango/ux/gen/dev/unmango/ux/v1alpha1"
@@ -36,8 +38,10 @@ func (generator) Generate(ctx context.Context, req *uxv1alpha1.GenerateRequest) 
 			return nil, err
 		}
 
+		ext := filepath.Ext(input)
+		output := strings.ReplaceAll(input, ext, ".dummy"+ext)
 		_, err = client.Write(ctx, &uxv1alpha1.WriteRequest{
-			Name: &input,
+			Name: &output,
 			Data: res.Data,
 		})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -62,7 +62,7 @@ var _ = Describe("E2e", func() {
 			)))
 		})
 
-		It("should echo back its input", func(ctx context.Context) {
+		It("should echo back the input with a modified name", func(ctx context.Context) {
 			p := plugin.LocalBinary(dummyPath)
 			inputs := []string{"input.txt"}
 
@@ -73,8 +73,8 @@ var _ = Describe("E2e", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.Outputs).To(Equal([]string{"input.txt"}))
-			r, err := srv.Output("input.txt")
-			Expect(err).NotTo(HaveOccurred())
+			r, err := srv.Output("input.dummy.txt")
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprint(srv))
 			data, err := io.ReadAll(r)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(data)).To(Equal("testing"))


### PR DESCRIPTION
Updates the plugin to modify the output file name by
adding a ".dummy" extension. This change ensures
the plugin generates distinct output files.

The e2e tests are updated to reflect this change.
