### PR TITLE
Ignores dummy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 .make/
 *.test
 *.txt
+*.dummy*
 
 .envrc
 .vscode/*


### PR DESCRIPTION
Adds a pattern to the `.gitignore` file to prevent accidental
committing of dummy files used for testing or development
purposes.

This helps to keep the repository clean and focused on relevant
source code and project assets.
